### PR TITLE
Fix mixing

### DIFF
--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -47,7 +47,8 @@ impl Add<&Self> for Frame {
         let left = self.left + rhs.left;
         let right = match (self.right, rhs.right) {
             (None, None) => None,
-            (None, Some(r)) | (Some(r), None) => Some(r),
+            (None, Some(r)) => Some(self.left + r),
+            (Some(r), None) => Some(r + rhs.left),
             (Some(a), Some(b)) => Some(a + b),
         };
         Self { left, right }

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -40,10 +40,10 @@ impl Frame {
     }
 }
 
-impl Add<&Self> for Frame {
+impl Add<Self> for Frame {
     type Output = Self;
 
-    fn add(self, rhs: &Self) -> Self {
+    fn add(self, rhs: Self) -> Self {
         let left = self.left + rhs.left;
         let right = match (self.right, rhs.right) {
             (None, None) => None,

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -21,19 +21,18 @@ pub trait Processor {
     /// Get the next frame for the processor.
     fn process_children(&mut self, cn: &mut [Node]) -> Option<Frame> {
         let mut sum = Frame::zero();
-        let mut count = 0;
+        let mut empty = true;
         for node in cn.iter_mut() {
             let Some(frame) = node.next_frame() else {
                 continue;
             };
-            sum = sum + &frame;
-            count += 1;
+            sum = sum + frame;
+            empty = false;
         }
-        if count == 0 {
+        if empty {
             return None;
         }
-        let f = sum / count as f32;
-        self.process_frame(f)
+        self.process_frame(sum)
     }
 
     fn process_frame(&mut self, f: Frame) -> Option<Frame> {

--- a/src/processors.rs
+++ b/src/processors.rs
@@ -30,7 +30,7 @@ impl Processor for AllForOne {
             return None;
         }
         for node in cn.iter_mut() {
-            sum = sum + &node.next_frame()?;
+            sum = sum + node.next_frame()?;
         }
         let f = sum / cn.len() as f32;
         self.process_frame(f)
@@ -84,7 +84,7 @@ impl Processor for Loop {
                 node.reset();
                 node.next_frame()?
             };
-            sum = sum + &f;
+            sum = sum + f;
         }
         Some(sum / cn.len() as f32)
     }


### PR DESCRIPTION
A few fixes for mixing issues that affected [Blutti](https://github.com/ollej/firefly-blutti) by @ollej:

1. When mixing stereo with mono, duplicate the mono channel to both stereo channels (instead of mixing it only into the left one)
2. By default, when mixing sound from multiple nodes, don't average their amplitudes. Without it, adding new nodes will change the volume of other nodes in the mix (the theme song going quieter when game sounds play).